### PR TITLE
Various edge-case fixes

### DIFF
--- a/cytools/polytope.py
+++ b/cytools/polytope.py
@@ -801,6 +801,49 @@ class Polytope:
             return self.points_to_indices(self._points)
         return np.array(self._points)
 
+    def pts(self, as_indices=False):
+        """
+        **Description:**
+        [synonym of Polytope.points]
+
+        Returns the lattice points of the polytope.
+
+        :::note
+        Points are sorted so that interior points are first, and then the
+        rest are arranged by decreasing number of saturated inequalities and
+        lexicographically. For reflexive polytopes this is useful since the
+        origin will be at index 0 and boundary points interior to facets will
+        be last.
+        :::
+
+        **Arguments:**
+        - `as_indices` *(bool)*: Return the points as indices of the full
+          list of points of the polytope.
+
+        **Returns:**
+        *(numpy.ndarray)* The list of lattice points of the polytope.
+
+        **Example:**
+        We construct a polytope and compute the lattice points. One can verify
+        that the first point is the only interior point, and the last three
+        points are the ones interior to facets. Thus it follows the
+        aforementioned ordering.
+        ```python {2}
+        p = Polytope([[1,0,0,0],[0,1,0,0],[0,0,1,0],[0,0,0,1],[-1,-1,-6,-9]])
+        p.points()
+        # array([[ 0,  0,  0,  0],
+        #        [-1, -1, -6, -9],
+        #        [ 0,  0,  0,  1],
+        #        [ 0,  0,  1,  0],
+        #        [ 0,  1,  0,  0],
+        #        [ 1,  0,  0,  0],
+        #        [ 0,  0, -2, -3],
+        #        [ 0,  0, -1, -2],
+        #        [ 0,  0, -1, -1],
+        #        [ 0,  0,  0, -1]])
+        """
+        return self.points(as_indices)
+
     def interior_points(self, as_indices=False):
         """
         **Description:**

--- a/cytools/polytope.py
+++ b/cytools/polytope.py
@@ -801,49 +801,6 @@ class Polytope:
             return self.points_to_indices(self._points)
         return np.array(self._points)
 
-    def pts(self, as_indices=False):
-        """
-        **Description:**
-        [synonym of Polytope.points]
-
-        Returns the lattice points of the polytope.
-
-        :::note
-        Points are sorted so that interior points are first, and then the
-        rest are arranged by decreasing number of saturated inequalities and
-        lexicographically. For reflexive polytopes this is useful since the
-        origin will be at index 0 and boundary points interior to facets will
-        be last.
-        :::
-
-        **Arguments:**
-        - `as_indices` *(bool)*: Return the points as indices of the full
-          list of points of the polytope.
-
-        **Returns:**
-        *(numpy.ndarray)* The list of lattice points of the polytope.
-
-        **Example:**
-        We construct a polytope and compute the lattice points. One can verify
-        that the first point is the only interior point, and the last three
-        points are the ones interior to facets. Thus it follows the
-        aforementioned ordering.
-        ```python {2}
-        p = Polytope([[1,0,0,0],[0,1,0,0],[0,0,1,0],[0,0,0,1],[-1,-1,-6,-9]])
-        p.points()
-        # array([[ 0,  0,  0,  0],
-        #        [-1, -1, -6, -9],
-        #        [ 0,  0,  0,  1],
-        #        [ 0,  0,  1,  0],
-        #        [ 0,  1,  0,  0],
-        #        [ 1,  0,  0,  0],
-        #        [ 0,  0, -2, -3],
-        #        [ 0,  0, -1, -2],
-        #        [ 0,  0, -1, -1],
-        #        [ 0,  0,  0, -1]])
-        """
-        return self.points(as_indices)
-
     def interior_points(self, as_indices=False):
         """
         **Description:**
@@ -1001,6 +958,48 @@ class Polytope:
         if as_indices:
             return self.points_to_indices(self._points_not_interior_to_facets)
         return np.array(self._points_not_interior_to_facets)
+
+    def pts(self, as_indices=False):
+        """
+        **Description:**
+        [synonym of Polytope.points]
+        """
+        return self.points(as_indices)
+
+    def interior_pts(self, as_indices=False):
+        """
+        **Description:**
+        [synonym of Polytope.interior_points]
+        """
+        return self.interior_points(as_indices)
+
+    def boundary_pts(self, as_indices=False):
+        """
+        **Description:**
+        [synonym of Polytope.boundary_points]
+        """
+        return self.boundary_points(as_indices)
+
+    def pts_interior_to_facets(self, as_indices=False):
+        """
+        **Description:**
+        [synonym of Polytope.points_interior_to_facets]
+        """
+        return self.points_interior_to_facets(as_indices)
+
+    def boundary_pts_not_interior_to_facets(self, as_indices=False):
+        """
+        **Description:**
+        [synonym of Polytope.boundary_points_not_interior_to_facets]
+        """
+        return self.boundary_points_not_interior_to_facets(as_indices)
+
+    def pts_not_interior_to_facets(self, as_indices=False):
+        """
+        **Description:**
+        [synonym of Polytope.points_not_interior_to_facets]
+        """
+        return self.points_not_interior_to_facets(as_indices)
 
     def is_reflexive(self):
         """

--- a/cytools/polytope.py
+++ b/cytools/polytope.py
@@ -2926,7 +2926,7 @@ class Polytope:
             pts_ind = tuple(set(points))
             if min(pts_ind) < 0 or max(pts_ind) > self.points().shape[0]:
                 raise Exception("An index is out of the allowed range.")
-            include_origin = 0 in pts_ind
+
         elif include_points_interior_to_facets is None:
             pts_ind = (tuple(range(self.points_not_interior_to_facets().shape[0]))
                         if self.is_reflexive()
@@ -3035,7 +3035,7 @@ class Polytope:
             pts_ind = tuple(set(points))
             if min(pts_ind) < 0 or max(pts_ind) > self.points().shape[0]:
                 raise Exception("An index is out of the allowed range.")
-            include_origin = 0 in pts_ind
+
         elif include_points_interior_to_facets is None:
             pts_ind = (tuple(range(self.points_not_interior_to_facets().shape[0]))
                         if self.is_reflexive()
@@ -3187,7 +3187,7 @@ class Polytope:
             pts_ind = tuple(set(points))
             if min(pts_ind) < 0 or max(pts_ind) > self.points().shape[0]:
                 raise Exception("An index is out of the allowed range.")
-            include_origin = 0 in pts_ind
+
         elif include_points_interior_to_facets is None:
             pts_ind = (tuple(range(self.points_not_interior_to_facets().shape[0]))
                         if self.is_reflexive()
@@ -3307,7 +3307,7 @@ class Polytope:
             pts_ind = tuple(set(points))
             if min(pts_ind) < 0 or max(pts_ind) > self.points().shape[0]:
                 raise Exception("An index is out of the allowed range.")
-            include_origin = 0 in pts_ind
+
         elif include_points_interior_to_facets is None:
             pts_ind = (tuple(range(self.points_not_interior_to_facets().shape[0]))
                         if self.is_reflexive()

--- a/cytools/polytope.py
+++ b/cytools/polytope.py
@@ -791,7 +791,7 @@ class Polytope:
         is in the interior of a facet (True) or not (False).
         """
         if self.__interior_to_facet_flags is None:
-            if self._dim == 0:
+            if self._dim <= 1:
                 self.__interior_to_facet_flags = np.array([False for pt in self._points_saturated()])
             else:
                 self.__interior_to_facet_flags = np.array([len(pt[1]) == 1 for pt in self._points_saturated()])

--- a/cytools/triangulation.py
+++ b/cytools/triangulation.py
@@ -639,7 +639,7 @@ class Triangulation:
                             self.cpl_cone(include_points_not_in_triangulation=False).is_solid(backend=backend))
         return self._is_regular
 
-    def is_star(self, star_origin=0):
+    def is_star(self, star_origin=0, manual_origin=False):
         """
         **Description:**
         Returns True if the triangulation is star and False otherwise.
@@ -647,6 +647,10 @@ class Triangulation:
         **Arguments:**
         - `star_origin` *(int, optional, default=0)*: The index of the
           origin of the star triangulation
+        - `manual_origin` *(bool, optional, default=False)*: Truth
+          value indicating whether to use the manually-given origin
+          (star_origin) or to just use points_to_indices to find
+          the origin
 
         **Returns:**
         *(bool)* The truth value of the triangulation being star.
@@ -660,6 +664,14 @@ class Triangulation:
         # True
         ```
         """
+        if not manual_origin:
+            try:
+                # manually calculate the origin's index
+                star_origin = self.points_to_indices([0]*self.dim())
+            except:
+                # the origin isn't inside the polytope
+                self._is_star = False
+
         if self._is_star is not None:
             return self._is_star
         self._is_star = all(star_origin in s for s in self._simplices)

--- a/cytools/triangulation.py
+++ b/cytools/triangulation.py
@@ -562,7 +562,9 @@ class Triangulation:
     def dim(self):
         """
         **Description:**
-        Returns the dimension of the triangulation.
+        Returns the dimension of the triangulation. Since triangulation requires
+        the polytope to be full dimensional, this is the same as the ambient
+        dimension.
 
         **Arguments:**
         None.


### PR DESCRIPTION
For non-reflexive polytopes, is_star failed because it assumed the origin had index 0 but this was not always the case.

For 1D polytopes, the classification of points (e.g., boundary_points_not_interior_to_facets) was faulty

Added synonyms of various point getters (e.g., 'interior_pts' also works now as a synonym of 'interior_points')

Deleted unused local variable ('include_origin')