### PR TITLE
fixed infeasible at degree bug

### DIFF
--- a/cytools/cone.py
+++ b/cytools/cone.py
@@ -930,7 +930,8 @@ class Cone:
 
     def find_lattice_points(self, min_points=None, max_deg=None,
                             grading_vector=None, max_coord=1000,
-                            filter_function=None, process_function=None):
+                            filter_function=None, process_function=None,
+                            verbose=True):
         """
         **Description:**
         Finds lattice points in the cone. The points are found in the region
@@ -1076,7 +1077,8 @@ class Cone:
             solver = cp_model.CpSolver()
             status = solver.SearchForAllSolutions(model, solution_storage)
             if status != cp_model.OPTIMAL:
-                raise Exception(f"There was a problem finding the points. Status code: {status}")
+                print(f"There was a problem finding the points. Status code: {solver.StatusName(status)}")
+                return
         else: # Else, we're going to add points until the minimum number is reached
             deg = 0
             while True:
@@ -1088,8 +1090,8 @@ class Cone:
                 model.Add(sum(ii*var[i] for i,ii in enumerate(grading_vector)) == deg)
                 solver = cp_model.CpSolver()
                 status = solver.SearchForAllSolutions(model, solution_storage)
-                if status != cp_model.OPTIMAL:
-                    raise Exception(f"There was a problem finding the points. Status code: {status}")
+                if status != cp_model.OPTIMAL and verbose:
+                    print(f"There was a problem finding the points at degree {deg}. Status code: {solver.StatusName(status)}")
                 deg += 1
                 if solution_storage._n_sol >= min_points:
                     break


### PR DESCRIPTION
If min_points was used and the cone had no lattice points at a given degree, previously, find_lattice_points would crash. Now, it just continues.

An example of this case is `cone = Cone([[1, 1, 1, 0], [2, 1, 2, -1], [0, 1, 2, 0], [2, 2, 3, -2], [2, 1, 2, 0], [1, 1, 2, -1], [0, 2, 1, 0]])`. This cone has a lattice point at degree=0, no lattice points at degree=1, but lattice points for degree>1. Previously, it'd fail upon `cone.find_lattice_points(min_points=100)` since the degree=1 case would be found infeasible. Now, only an optional warning is printed.