### PR TITLE
chore: delete CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-cy.tools


### PR DESCRIPTION
The CNAME file used to be necessary for GitHub pages, but now it is not used.