### PR TITLE
Add deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,56 @@
+name: Deploy
+
+on:
+  workflow_dispatch:
+  release:
+    types:
+      - published
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  make-sdist:
+    name: Make SDist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build SDist
+        run: pipx run build --sdist
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ci-sdist
+          path: dist/*.tar.gz
+
+  make-wheel:
+    name: Make Wheel
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build Wheel
+        run: pipx run build --wheel
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ci-wheel
+          path: dist/*.tar.gz
+
+  deploy-pypi:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    needs: [make-sdist, make-wheel]
+    environment:
+      name: pypi
+      url: https://pypi.org/p/cytools
+    permissions:
+      id-token: write
+    if: github.event_name == 'release' && github.event.action == 'published'
+    steps:
+      - name: Download wheels
+        uses: actions/download-artifact@v4
+        with:
+          pattern: ci-*
+          path: dist
+          merge-multiple: true
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,3 +52,6 @@ Repository = "https://github.com/LiamMcAllisterGroup/cytools"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/cytools"]
+
+[tool.hatch.build.targets.sdist]
+packages = ["src/cytools"]


### PR DESCRIPTION
This PR adds a deploy workflow so that every time a new release is published it uploads the wheel and sdist to PyPI.