### PR TITLE
Fix face_lattice referral to Cone

### DIFF
--- a/src/cytools/cone.py
+++ b/src/cytools/cone.py
@@ -45,6 +45,7 @@ import qpsolvers
 from scipy import sparse
 from scipy.optimize import linprog, nnls
 import latticepts
+from __future__ import annotations
 
 # CYTools imports
 from cytools import config
@@ -919,7 +920,7 @@ class Cone:
 
     def face_lattice(
         self, codim: int = None, include_self: bool = False, verbosity: int = 0
-    ) -> tuple(tuple(Cone)) | tuple(Cone):
+    ) -> tuple[tuple[Cone]] | tuple[Cone]:
         """
         **Description:**
         Computes the positive-dimensional face lattice of a pointed cone.

--- a/src/cytools/cone.py
+++ b/src/cytools/cone.py
@@ -18,6 +18,7 @@
 # Description:  This module contains tools designed to perform cone
 #               computations.
 # -----------------------------------------------------------------------------
+from __future__ import annotations
 
 # 'standard' imports
 from ast import literal_eval
@@ -45,7 +46,6 @@ import qpsolvers
 from scipy import sparse
 from scipy.optimize import linprog, nnls
 import latticepts
-from __future__ import annotations
 
 # CYTools imports
 from cytools import config


### PR DESCRIPTION
Changing parenthesis to square brackets in output type specification, allowing detection of Cone before the class definition ends.