### PR TITLE
Add future annotations import to cone.py

### DIFF
--- a/src/cytools/cone.py
+++ b/src/cytools/cone.py
@@ -20,6 +20,7 @@
 # -----------------------------------------------------------------------------
 
 # 'standard' imports
+from __future__ import annotations
 from ast import literal_eval
 from collections.abc import Iterable
 from copy import deepcopy


### PR DESCRIPTION
Enable postponed evaluation of type annotations in src/cytools/cone.py by adding `from __future__ import annotations`. This allows forward references in type hints.