### PR TITLE
Make the external normaliz dependency explicit for hilbert_basis

### DIFF
--- a/src/cytools/cone.py
+++ b/src/cytools/cone.py
@@ -29,6 +29,7 @@ import joblib
 from multiprocessing import cpu_count
 import os
 import random
+import shutil
 import string
 import subprocess
 import warnings
@@ -1952,6 +1953,11 @@ class Cone:
         """
         if self._hilbert_basis is not None:
             return np.array(self._hilbert_basis)
+        if shutil.which("normaliz") is None:
+            raise RuntimeError(
+                "Hilbert basis computation requires the external 'normaliz' "
+                "executable to be installed and available on PATH."
+            )
         # Generate a random project name so that it doesn't conflict with
         # other computations
         letters = string.ascii_lowercase

--- a/tests/test_cone.py
+++ b/tests/test_cone.py
@@ -1,4 +1,7 @@
+import shutil
+
 import numpy as np
+import pytest
 
 from cytools import Cone
 
@@ -35,6 +38,10 @@ def test_find_lattice_points():
     assert len(pts) >= 20
 
 
+@pytest.mark.skipif(
+    shutil.which("normaliz") is None,
+    reason="requires the external normaliz executable",
+)
 def test_hibert_basis():
     c = Cone([[1, 3], [2, 1]])
     hb = c.hilbert_basis()


### PR DESCRIPTION
## Summary
- raise a clear `RuntimeError` when the external `normaliz` executable is missing
- skip the Hilbert-basis test when `normaliz` is not installed

## Why
The current failure mode is an opaque missing-binary error even though `normaliz` is an external runtime dependency.

## Validation
- targeted `hilbert_basis` check: `1 skipped`
- `python3 -m py_compile src/cytools/cone.py tests/test_cone.py`

Contributed by Physical Superintelligence PBC (PSI).
