### PR TITLE
Fix translated reflexive polytopes in Polytope.is_reflexive()

### DIFF
--- a/src/cytools/polytope.py
+++ b/src/cytools/polytope.py
@@ -463,7 +463,7 @@ class Polytope:
         # self._ineqs_input
         # self._ineqs_optimal
         # self._poly_optimal
-        self._is_reflexive = None
+        self._is_reflexive = dict()
 
         # input, optimal points (DON'T CLEAR! Set in init...)
         # self._labels2inputPts
@@ -1543,23 +1543,42 @@ class Polytope:
             return False
 
         # check if we know the answer
-        if self._is_reflexive is not None:
-            return self._is_reflexive
+        if allow_translations in self._is_reflexive:
+            return self._is_reflexive[allow_translations]
 
         # calculate the answer
-        if self.is_solid():
-            self._is_reflexive = all(
-                c == 1 for c in self._ineqs_input[:, -1]
-            )
-        else:
-            if allow_translations:
-                p = Polytope(self.points(optimal=True))
+        if allow_translations:
+            pts_opt = self.points(optimal=True)
+            if len(pts_opt) == 0 or len(self.interior_points()) != 1:
+                self._is_reflexive[allow_translations] = False
             else:
-                p = Polytope(lll_reduce(self.points())[:,-self.dim():])
-            self._is_reflexive = p.is_reflexive()
+                # The unique interior point is listed first, so recenter there
+                # before checking reflexivity in the strict sense.
+                p = Polytope(
+                    pts_opt - pts_opt[0],
+                    backend=self._backend,
+                    deterministic_glsm_basis=self._deterministic_glsm_basis,
+                )
+                self._is_reflexive[allow_translations] = p.is_reflexive(
+                    allow_translations=False
+                )
+        else:
+            if self.is_solid():
+                self._is_reflexive[allow_translations] = all(
+                    c == 1 for c in self._ineqs_input[:, -1]
+                )
+            else:
+                p = Polytope(
+                    lll_reduce(self.points())[:, -self.dim() :],
+                    backend=self._backend,
+                    deterministic_glsm_basis=self._deterministic_glsm_basis,
+                )
+                self._is_reflexive[allow_translations] = p.is_reflexive(
+                    allow_translations=False
+                )
 
         # return
-        return self._is_reflexive
+        return self._is_reflexive[allow_translations]
 
     # symmetries
     # ==========

--- a/tests/test_polytope.py
+++ b/tests/test_polytope.py
@@ -191,6 +191,25 @@ def test_is_reflexive():
     assert p.is_reflexive()
 
 
+def test_is_reflexive_allow_translations_for_translated_polygon():
+    p = Polytope([[11, 10], [10, 11], [9, 9]])
+    assert p.is_reflexive()
+    assert not p.is_reflexive(allow_translations=False)
+
+
+def test_is_reflexive_allow_translations_for_embedded_polygon():
+    p = Polytope([[0, 0, 11, 10], [0, 0, 10, 11], [0, 0, 9, 9]])
+    assert p.is_reflexive()
+    assert not p.is_reflexive(allow_translations=False)
+
+
+def test_is_reflexive_cache_keeps_translation_modes_separate():
+    p = Polytope([[11, 10], [10, 11], [9, 9]])
+    assert not p.is_reflexive(allow_translations=False)
+    assert p.is_reflexive()
+    assert not p.is_reflexive(allow_translations=False)
+
+
 def test_is_solid():
     p = Polytope([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [-1, -1, -1, 0]])
     assert not p.is_solid()


### PR DESCRIPTION
## Summary
- key the `is_reflexive` cache by `allow_translations`
- recenter translated polytopes on the unique interior lattice point before the strict reflexivity check
- add regression coverage for translated and embedded translated examples

## Why
Translated reflexive polytopes could be reported as non-reflexive, and cached results could leak between translation modes.

## Validation
- `python3 -m py_compile src/cytools/polytope.py tests/test_polytope.py`
- full pytest was blocked locally by existing dependency environment gaps on `origin/main`

Contributed by Physical Superintelligence PBC (PSI).
