### PR TITLE
Fix call-order dependence in Fan.intersection_numbers()

### DIFF
--- a/src/cytools/vector_config/fan.py
+++ b/src/cytools/vector_config/fan.py
@@ -31,6 +31,9 @@ from typing import Union
 from cytools import Cone, HPolytope, utils
 from cytools.triangulation import Triangulation
 
+_INTERSECTION_NUMBERS_DEFAULT_EPS = 1e-4
+_INTERSECTION_NUMBERS_DEFAULT_DIGITS = 10
+
 
 class Fan(regfans.fan.Fan):
     """
@@ -280,8 +283,8 @@ class Fan(regfans.fan.Fan):
         in_basis: bool = False,
         symmetrize: bool = False,
         as_np_array: bool = False,
-        eps: float = 1e-4,
-        digits: int = 10,
+        eps: float = _INTERSECTION_NUMBERS_DEFAULT_EPS,
+        digits: int = _INTERSECTION_NUMBERS_DEFAULT_DIGITS,
         verbosity: int = 0,
     ) -> Union[dict, "ArrayLike"]:
         """
@@ -298,8 +301,13 @@ class Fan(regfans.fan.Fan):
                          give components kappa[i,j,k] for i<=j<=k.
         - `as_np_array`: Whether to format the intersection numbers as a NumPy
                          array.
-        - `eps`:         Tolerance for rejecting 0 intersection numbers.
-        - `digits`:      How many digits to round to during the computations.
+        - `eps`:         Compatibility-only tolerance for filtering near-zero
+                         output entries. This does not affect the cached
+                         geometric tensor and should normally be left at the
+                         default.
+        - `digits`:      Compatibility-only rounding for the returned values.
+                         This does not affect the cached geometric tensor and
+                         should normally be left at the default.
         - `verbosity`:   The verbosity level. Higher is more verbose.
 
         **Returns:**
@@ -308,12 +316,57 @@ class Fan(regfans.fan.Fan):
         if not hasattr(self, '_kappa'):
             self._kappa = collections.defaultdict(float)
             self._kappa_known_labels = set()
+        if not hasattr(self, "_kappa_default"):
+            self._kappa_default = None
 
         if not self.is_triangulation():
             raise ValueError("Fan is not a triangulation!")
 
         if as_np_array:
             symmetrize = True
+
+        def format_kappa(
+            raw_kappa,
+            *,
+            eps_value,
+            digits_value,
+            symmetrize_output,
+            as_np_array_output,
+        ):
+            if (
+                eps_value == _INTERSECTION_NUMBERS_DEFAULT_EPS
+                and digits_value == _INTERSECTION_NUMBERS_DEFAULT_DIGITS
+                and not symmetrize_output
+                and not as_np_array_output
+                and self._kappa_default is not None
+            ):
+                return dict(self._kappa_default)
+
+            kappa = dict(raw_kappa)
+
+            for k in list(kappa.keys()):
+                v = kappa[k]
+
+                if np.abs(v) < eps_value:
+                    del kappa[k]
+                    continue
+
+                if digits_value is not None:
+                    kappa[k] = round(v, digits_value)
+
+            if symmetrize_output:
+                keys = list(kappa.keys())
+                for k in keys:
+                    for k_perm in itertools.permutations(k):
+                        kappa[tuple(k_perm)] = kappa[k]
+
+            if as_np_array_output:
+                kappa_np = np.zeros(self.ambient_dim*(self.vc.size+1,))
+                for k, v in kappa.items():
+                    kappa_np[k] = v
+                return kappa_np
+
+            return kappa
 
         # get relevant labels
         # -------------------
@@ -388,7 +441,7 @@ class Fan(regfans.fan.Fan):
                 else:
                     # map labels to indices...
                     for k,v in kappa.items():
-                        kappa_np[*[ki-1 for ki in k]] = v
+                        kappa_np[tuple(ki - 1 for ki in k)] = v
                 return kappa_np
             
             return kappa
@@ -397,22 +450,22 @@ class Fan(regfans.fan.Fan):
         # -----------------
         # check if we know the answer
         if (self._kappa_known_labels == set(self.labels)):
-            kappa = dict(self._kappa)
+            if self._kappa_default is None:
+                self._kappa_default = format_kappa(
+                    self._kappa,
+                    eps_value=_INTERSECTION_NUMBERS_DEFAULT_EPS,
+                    digits_value=_INTERSECTION_NUMBERS_DEFAULT_DIGITS,
+                    symmetrize_output=False,
+                    as_np_array_output=False,
+                )
 
-            # symmetrize
-            if symmetrize:
-                keys = list(kappa.keys())
-                for k in keys:
-                    for k_perm in itertools.permutations(k):
-                        kappa[tuple(k_perm)] = kappa[k]
-
-            if as_np_array:
-                kappa_np = np.zeros(self.ambient_dim*(self.vc.size+1,))
-                for k,v in kappa.items():
-                    kappa_np[k] = v
-                return kappa_np
-
-            return kappa
+            return format_kappa(
+                self._kappa,
+                eps_value=eps,
+                digits_value=digits,
+                symmetrize_output=symmetrize,
+                as_np_array_output=as_np_array,
+            )
 
         # don't know the answer... need to calculate it...
         # setup
@@ -561,32 +614,15 @@ class Fan(regfans.fan.Fan):
         for kappa_n in kappa_nzeros[1:]:
             self._kappa.update(kappa_n)
 
-        # clean kappa
-        # -----------
-        # (i.e., trim 0s, round values)
-        keys = list(self._kappa.keys())
-        for k in keys:
-            v = self._kappa[k]
-
-            # delete 0 entries
-            if np.abs(v) < eps:
-                del self._kappa[k]
-            else:
-                # round the floating point numbers
-                if digits is not None:
-                    v_round = round(v, digits)
-                else:
-                    v_round = v
-
-                # optionally, symmetrize
-                if symmetrize:
-                    for k_perm in itertools.permutations(k):
-                        self._kappa[tuple(k_perm)] = v_round
-                else:
-                    self._kappa[k] = v_round
-
         # save kappa labels (for caching)
         self._kappa_known_labels = set(self.labels)
+        self._kappa_default = format_kappa(
+            self._kappa,
+            eps_value=_INTERSECTION_NUMBERS_DEFAULT_EPS,
+            digits_value=_INTERSECTION_NUMBERS_DEFAULT_DIGITS,
+            symmetrize_output=False,
+            as_np_array_output=False,
+        )
 
         return self.intersection_numbers(
             pushed_down=pushed_down,
@@ -1018,7 +1054,7 @@ def curve_to_gv(fan, kappa, circ, verbosity=0):
             
             if set(c).issubset(fan.vc.divisor_basis):
                 c_inds = fan.vc.labels_to_inds(c, ambient_labels=fan.vc.divisor_basis)
-                kappa_c = kappa[*c_inds]
+                kappa_c = kappa[tuple(c_inds)]
                 if False:
                     A = kappa_c
 

--- a/tests/test_fan.py
+++ b/tests/test_fan.py
@@ -1,0 +1,51 @@
+import numpy as np
+
+from cytools import Polytope
+
+
+def fan_fixture():
+    p = Polytope(
+        [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1], [-1, -1, -6, -9]]
+    )
+    return p.triangulate().fan()
+
+
+def test_intersection_numbers_call_order_digits():
+    fan_after = fan_fixture()
+    fan_fresh = fan_fixture()
+
+    fan_after.intersection_numbers(digits=0, symmetrize=False)
+    after = fan_after.intersection_numbers(symmetrize=False)
+    fresh = fan_fresh.intersection_numbers(symmetrize=False)
+
+    assert after == fresh
+    assert len(after) == 121
+    assert np.isclose(after[(1, 1, 2, 6)], 0.5)
+    assert np.isclose(after[(1, 1, 6, 6)], 1 / 6)
+    assert np.isclose(after[(2, 2, 2, 2)], 121.5)
+
+
+def test_intersection_numbers_call_order_eps():
+    fan_after = fan_fixture()
+    fan_fresh = fan_fixture()
+
+    fan_after.intersection_numbers(eps=0.6, digits=None, symmetrize=False)
+    after = fan_after.intersection_numbers(symmetrize=False)
+    fresh = fan_fresh.intersection_numbers(symmetrize=False)
+
+    assert after == fresh
+    assert len(after) == 121
+    assert (1, 1, 2, 6) in after
+    assert np.isclose(after[(1, 1, 3, 6)], 1 / 3)
+
+
+def test_mori_rays_after_low_precision_intersection_numbers():
+    fan_after = fan_fixture()
+    fan_fresh = fan_fixture()
+
+    fan_after.intersection_numbers(digits=0, symmetrize=False)
+
+    after = sorted(map(tuple, fan_after.mori_rays().tolist()))
+    fresh = sorted(map(tuple, fan_fresh.mori_rays().tolist()))
+
+    assert after == fresh


### PR DESCRIPTION
## Summary
- keep the cached geometric tensor separate from per-call formatting in `Fan.intersection_numbers()`
- preserve a fast default cache-hit path
- add regressions for `digits`, `eps`, and downstream `mori_rays()` stability

## Why
Low-precision formatting calls could mutate cached intersection data and poison later full-precision queries.

## Validation
- `pytest tests/test_fan.py -q` -> `3 passed`

Contributed by Physical Superintelligence PBC (PSI).
