### PR TITLE
Declare direct dependencies and make uv install test tools by default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,14 @@ gnn = [
   "dualgnn"
 ]
 
+[dependency-groups]
+dev = [
+  "pytest",
+]
+
+[tool.uv]
+default-groups = ["dev"]
+
 [project.urls]
 Homepage = "https://cy.tools"
 Documentation = "https://cy.tools/docs/documentation/"


### PR DESCRIPTION
## Summary
- add a `dev` dependency group with `pytest`
- make `uv` include the `dev` group by default

## Why
Local `uv` installs currently omit test tools by default. The direct runtime dependencies originally covered by this PR are now already present on `main`.

## Notes
This PR is intentionally limited to uv defaults. It does not change Python support metadata or `triangulumancer` version markers.

## Validation
- parsed `pyproject.toml` and asserted the intended fields
- `git diff --check origin/main...HEAD -- pyproject.toml`

Contributed by Physical Superintelligence PBC (PSI).
