### PR TITLE
Fix zero_as_anticanonical intersection_numbers caching

### DIFF
--- a/src/cytools/calabiyau.py
+++ b/src/cytools/calabiyau.py
@@ -1438,17 +1438,17 @@ class CalabiYau:
         # Now intersection numbers have been computed
         # We now compute the intersection numbers of the basis if necessary
         if zero_as_anticanonical and not in_basis:
-            self._intersection_numbers[(True, False, exact_arithmetic, "dok")] = (
-                self._intersection_numbers[(False, False, exact_arithmetic, "dok")]
-            )
-            for ii in self._intersection_numbers[
-                (True, False, exact_arithmetic, "dok")
-            ]:
-                if 0 not in ii:
-                    continue
-                self._intersection_numbers[(True, False, exact_arithmetic, "dok")][
-                    ii
-                ] *= (-1 if sum(jj == 0 for jj in ii) % 2 == 1 else 1)
+            base_intnums = self._intersection_numbers[
+                (False, False, exact_arithmetic, "dok")
+            ]
+            self._intersection_numbers[(True, False, exact_arithmetic, "dok")] = {
+                ii: (
+                    val * (-1 if sum(jj == 0 for jj in ii) % 2 == 1 else 1)
+                    if 0 in ii
+                    else val
+                )
+                for ii, val in base_intnums.items()
+            }
         elif in_basis:
             basis = self.divisor_basis()
             if len(basis.shape) == 2:  # If basis is matrix

--- a/src/cytools/toricvariety.py
+++ b/src/cytools/toricvariety.py
@@ -1632,15 +1632,17 @@ class ToricVariety:
         # Now intersection numbers have been computed
         # We now compute the intersection numbers of the basis if necessary
         if zero_as_anticanonical and not in_basis:
-            self._intersection_numbers[args_id] = self._intersection_numbers[
+            base_intnums = self._intersection_numbers[
                 (False, False, exact_arithmetic, "dok")
             ]
-            for ii in self._intersection_numbers[args_id]:
-                if 0 not in ii:
-                    continue
-                self._intersection_numbers[args_id][ii] *= (
-                    -1 if sum(ii == 0) % 2 == 1 else 1
+            self._intersection_numbers[args_id] = {
+                ii: (
+                    val * (-1 if sum(jj == 0 for jj in ii) % 2 == 1 else 1)
+                    if 0 in ii
+                    else val
                 )
+                for ii, val in base_intnums.items()
+            }
         elif in_basis:
             basis = self.divisor_basis()
             if len(basis.shape) == 2:  # If basis is matrix

--- a/tests/test_calabiyau.py
+++ b/tests/test_calabiyau.py
@@ -118,6 +118,26 @@ def test_intersection_numbers():
     assert len(intnum_basis) == 3
 
 
+def test_intersection_numbers_zero_as_anticanonical():
+    p = Polytope(
+        [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1], [-1, -1, -6, -9]]
+    )
+    t = p.triangulate(backend="qhull")
+    cy = t.get_cy()
+
+    canonical = cy.intersection_numbers()
+    anticanonical = cy.intersection_numbers(zero_as_anticanonical=True)
+
+    assert len(anticanonical) == len(canonical)
+
+    for ii, val in canonical.items():
+        zero_count = sum(jj == 0 for jj in ii)
+        expected = val * (-1 if zero_count % 2 == 1 else 1)
+        assert np.isclose(anticanonical[ii], expected)
+
+    assert cy.intersection_numbers() == canonical
+
+
 def test_is_smooth():
     p = Polytope(
         [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1], [-1, -1, -6, -9]]

--- a/tests/test_toricvariety.py
+++ b/tests/test_toricvariety.py
@@ -66,6 +66,26 @@ def test_intersection_numbers():
     assert len(intnum_basis) == 3
 
 
+def test_intersection_numbers_zero_as_anticanonical():
+    p = Polytope(
+        [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1], [-1, -1, -6, -9]]
+    )
+    t = p.triangulate(backend="qhull")
+    v = t.get_toric_variety()
+
+    canonical = v.intersection_numbers()
+    anticanonical = v.intersection_numbers(zero_as_anticanonical=True)
+
+    assert len(anticanonical) == len(canonical)
+
+    for ii, val in canonical.items():
+        zero_count = sum(jj == 0 for jj in ii)
+        expected = val * (-1 if zero_count % 2 == 1 else 1)
+        assert np.isclose(anticanonical[ii], expected)
+
+    assert v.intersection_numbers() == canonical
+
+
 def test_is_compact():
     p = Polytope(
         [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 1], [-1, -1, -1, -1]]


### PR DESCRIPTION
## Summary
- separate canonical and anticanonical intersection-number caches in `ToricVariety` and `CalabiYau`
- fix the zero-counting bug in the toric postprocessing path
- add targeted regressions for `zero_as_anticanonical=True`

## Why
Anticanonical queries could mutate canonical cached data and cause later plain `intersection_numbers()` calls to return incorrect values.

## Validation
- targeted anticanonical regression tests -> `2 passed`

Contributed by Physical Superintelligence PBC (PSI).
