### PR TITLE
Update vectorconfiguration.py

### DIFF
--- a/src/cytools/vector_config/vectorconfiguration.py
+++ b/src/cytools/vector_config/vectorconfiguration.py
@@ -77,7 +77,7 @@ class VectorConfiguration(regfans.VectorConfiguration):
 
         # some Polytope info
         p = Polytope(self.vectors(), labels=self.labels)
-        self._is_reflexive = p.is_reflexive()
+        self._is_reflexive = p.is_reflexive(allow_translations=False)
         self._poly = {self.labels: p}
 
         # some toric info


### PR DESCRIPTION
_is_reflexive is now defined from is_reflexive(allow_translations=False) of the convex hull of the defining vectors